### PR TITLE
feat: add npm publish workflow with trusted publishing [kid: #db2813d8]

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,22 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+      - run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow that publishes `teeny-cli` to npm when a GitHub release is created
- Uses npm trusted publishing (provenance) via OIDC so published packages get a verified provenance badge on npmjs.com

Task UUID: db2813d8-1e97-4384-85a4-6bb6624ae8aa

## Setup instructions

Before this workflow will work, you need to configure both npm and GitHub:

### 1. Link the GitHub repo to the npm package (trusted publishing)

1. Log in to [npmjs.com](https://www.npmjs.com/) and navigate to the `teeny-cli` package settings (or publish the package for the first time manually with `npm publish` if it doesn't exist yet)
2. Go to **Settings** > **Publishing access**
3. Under **Trusted Publishing** (or **Provenance**), click **Add a new provider**
4. Configure:
   - **Repository owner:** `yakkomajuri`
   - **Repository name:** `teeny`
   - **Workflow filename:** `publish.yml`
   - **Environment:** *(leave blank)*
5. Save

### 2. Add the `NPM_TOKEN` secret to GitHub

Even with trusted publishing/provenance, npm still requires an access token for authentication:

1. On npmjs.com, go to your **Access Tokens** page
2. Click **Generate New Token** > **Granular Access Token**
3. Configure the token:
   - **Name:** e.g. `github-actions-teeny`
   - **Expiration:** choose an appropriate expiry
   - **Packages:** select `teeny-cli` with **Read and write** permission
4. Copy the generated token
5. In the GitHub repo, go to **Settings** > **Secrets and variables** > **Actions**
6. Click **New repository secret**
7. Name: `NPM_TOKEN`, Value: paste the token

### 3. Publish a release

1. Update the version in `package.json` (e.g. `npm version patch`)
2. Push the tag: `git push --follow-tags`
3. Create a release on GitHub from that tag (or use `gh release create v<version>`)
4. The workflow will automatically publish to npm with provenance

### Verifying it works

After the first publish via this workflow, the package page on npmjs.com should show a green **Provenance** badge, linking back to the exact commit and workflow run that produced the package.

## Test plan

- [ ] Verify the workflow YAML is valid (check the Actions tab after merge)
- [ ] Create a GitHub release and confirm the workflow runs and publishes successfully
- [ ] Verify the published package shows a provenance badge on npmjs.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)